### PR TITLE
add option to specify css className

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,9 @@ Create a plugin that, when added to a ProseMirror instance, causes a
 decoration to show up at the drop position when something is dragged
 over the editor.
 
-Supports two options: `color` to set the color of the cursor (defaults
-to black) and `width` to set its with in pixels (defaults to 1).
+ - **`options`**`: ?Object`
+   - **`color`**`: ?string (default: black)`
+   - **`width`**`: ?number (default: 1)`
+   - **`class`**`: ?string`\
+   Adds a class to the cursor.\
+   *Layout overrides such as `width` are not recommended*

--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -12,6 +12,7 @@ class DropCursorView {
     this.editorView = editorView
     this.width = options.width || 1
     this.color = options.color || "black"
+    this.class = options.class || null
     this.cursorPos = null
     this.element = null
     this.timeout = null
@@ -62,6 +63,9 @@ class DropCursorView {
     let parent = this.editorView.dom.offsetParent
     if (!this.element) {
       this.element = parent.appendChild(document.createElement("div"))
+      if (this.class) {
+        this.element.className = this.class
+      }
       this.element.style.cssText = "position: absolute; z-index: 50; pointer-events: none; background-color: " + this.color
     }
     let parentRect = parent == document.body && getComputedStyle(parent).position == "static"


### PR DESCRIPTION
The only downside is that overriding the width or height via css will not work correctly (mention in documentation?)

Default is currently that it doesn't add any class when not specified.