### PR TITLE
IE 11 fix

### DIFF
--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -35,7 +35,7 @@ class DropCursorView {
     if (pos == this.cursorPos) return
     this.cursorPos = pos
     if (pos == null) {
-      this.element.remove()
+      this.element.parentNode.removeChild(this.element)
       this.element = null
     } else {
       this.updateOverlay()


### PR DESCRIPTION
The drop cursor Plugin doesn't work in Internet Explorer 11 because the remove method is not available. See https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove