### PR TITLE
cursor should always be on the top z-index stack

### DIFF
--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -62,7 +62,7 @@ class DropCursorView {
     let parent = this.editorView.dom.offsetParent
     if (!this.element) {
       this.element = parent.appendChild(document.createElement("div"))
-      this.element.style.cssText = "position: absolute; z-index: 50; pointer-events: none; background-color: " + this.color
+      this.element.style.cssText = "position: absolute; z-index: 2147483647; pointer-events: none; background-color: " + this.color
     }
     let parentRect = parent == document.body && getComputedStyle(parent).position == "static"
         ? {left: -pageXOffset, top: -pageYOffset} : parent.getBoundingClientRect()


### PR DESCRIPTION
All browsers clip a too high value to the max value except firefox <= 3.
Source: https://stackoverflow.com/questions/491052/minimum-and-maximum-value-of-z-index