### PR TITLE
Only create drop cursor if the view is editable.

### DIFF
--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -79,7 +79,7 @@ class DropCursorView {
 
   dragover(event) {
     let pos = this.editorView.posAtCoords({left: event.clientX, top: event.clientY})
-    if (pos) {
+    if (pos && !this.editorView.someProp("editable", editable => editable(this.editorView.state) === false)) {
       let target = pos.pos
       if (this.editorView.dragging && this.editorView.dragging.slice) {
         target = dropPoint(this.editorView.state.doc, target, this.editorView.dragging.slice)


### PR DESCRIPTION
Similar to ProseMirror/prosemirror-gapcursor#6 but for the drop cursor.

I would normally create a local var for the view or the state here, now that it's being accessed in the arrow function, but I tried to keep the change minimal. Let me know if that would be preferred.