### PR TITLE
Adds ability to disable dropCursor on Nodes

### DIFF
--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -28,7 +28,6 @@ class DropCursorView {
     this.width = options.width || 1
     this.color = options.color || "black"
     this.class = options.class
-    this.predicate = options.predicate || function () { return true }
     this.cursorPos = null
     this.element = null
     this.timeout = null
@@ -109,8 +108,11 @@ class DropCursorView {
     if (!this.editorView.editable) return
     let pos = this.editorView.posAtCoords({left: event.clientX, top: event.clientY})
     
-    const node = this.editorView.state.doc.nodeAt(pos.inside === -1 ? pos.pos : pos.inside)
-    if (node && node.type.spec.disableDropCursor && this.predicate()) return
+    const node = this.editorView.state.doc.nodeAt(pos.inside === -1 ? pos.pos : pos.inside);
+    const disableDropCursor = (node && node.type.spec.disableDropCursor) ? node.type.spec.disableDropCursor : false;
+    const isDropCursorDisabled = typeof disableDropCursor === 'function' ? disableDropCursor(this.editorView) : disableDropCursor;
+
+    if (isDropCursorDisabled) return;
     
     if (pos) {
       let target = pos.pos

--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -28,7 +28,6 @@ class DropCursorView {
     this.width = options.width || 1
     this.color = options.color || "black"
     this.class = options.class
-    this.disableClass = options.disableClass || 'disable-dropcursor'
     this.cursorPos = null
     this.element = null
     this.timeout = null
@@ -107,9 +106,13 @@ class DropCursorView {
 
   dragover(event) {
     if (!this.editorView.editable) return
-    const isDisabled = event.path.some(el => el.className && el.className.includes(this.disableClass))
-    if (isDisabled) return
     let pos = this.editorView.posAtCoords({left: event.clientX, top: event.clientY})
+    
+    // Disables dropcursor when Node disableDropCursor property is true
+    // and is not a draggable Node within the document
+    const node = this.editorView.state.doc.nodeAt(pos.pos);
+    if (node && node.type.spec.disableDropCursor && !this.editorView.dragging) return;
+    
     if (pos) {
       let target = pos.pos
       if (this.editorView.dragging && this.editorView.dragging.slice) {

--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -28,6 +28,7 @@ class DropCursorView {
     this.width = options.width || 1
     this.color = options.color || "black"
     this.class = options.class
+    this.predicate = options.predicate || function () { return true }
     this.cursorPos = null
     this.element = null
     this.timeout = null
@@ -108,10 +109,8 @@ class DropCursorView {
     if (!this.editorView.editable) return
     let pos = this.editorView.posAtCoords({left: event.clientX, top: event.clientY})
     
-    // Disables dropcursor when Node disableDropCursor property is true
-    // and is not a draggable Node within the document
-    const node = this.editorView.state.doc.nodeAt(pos.pos);
-    if (node && node.type.spec.disableDropCursor && !this.editorView.dragging) return;
+    const node = this.editorView.state.doc.nodeAt(pos.inside === -1 ? pos.pos : pos.inside)
+    if (node && node.type.spec.disableDropCursor && this.predicate()) return
     
     if (pos) {
       let target = pos.pos

--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -28,6 +28,7 @@ class DropCursorView {
     this.width = options.width || 1
     this.color = options.color || "black"
     this.class = options.class
+    this.disableClass = options.disableClass || 'disable-dropcursor'
     this.cursorPos = null
     this.element = null
     this.timeout = null
@@ -106,6 +107,8 @@ class DropCursorView {
 
   dragover(event) {
     if (!this.editorView.editable) return
+    const isDisabled = event.path.some(el => el.className && el.className.includes(this.disableClass))
+    if (isDisabled) return
     let pos = this.editorView.posAtCoords({left: event.clientX, top: event.clientY})
     if (pos) {
       let target = pos.pos

--- a/src/dropcursor.js
+++ b/src/dropcursor.js
@@ -110,7 +110,7 @@ class DropCursorView {
     
     const node = this.editorView.state.doc.nodeAt(pos.inside === -1 ? pos.pos : pos.inside);
     const disableDropCursor = (node && node.type.spec.disableDropCursor) ? node.type.spec.disableDropCursor : false;
-    const isDropCursorDisabled = typeof disableDropCursor === 'function' ? disableDropCursor(this.editorView) : disableDropCursor;
+    const isDropCursorDisabled = typeof disableDropCursor === 'function' ? disableDropCursor(this.editorView, pos) : disableDropCursor;
 
     if (isDropCursorDisabled) return;
     


### PR DESCRIPTION
This PR adds a `disableClass` which can be placed on certain Nodes that you might not want the `dropCursor` to appear on.

Use case: Imagine a custom atom Node that allows files to be dragged into it from the OS. Without this check to disable the dropCursor it will display the cursor above or below this custom Node, incorrectly indicating that the file will be dropped outside of the Node.