### PR TITLE
Pass drag event to disableDropCursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ to communication around the project.
 
    Nodes may add a `disableDropCursor` property to their spec to
    control the showing of a drop cursor inside them. This may be a
-   boolean or a function, which will be called with a view and a
-   position, and should return a boolean.
+   boolean or a function, which will be called with a view, a
+   position, and the DragEvent, and should return a boolean.
 
     * **`options`**
 

--- a/src/dropcursor.ts
+++ b/src/dropcursor.ts
@@ -120,7 +120,7 @@ class DropCursorView {
 
     let node = pos && pos.inside >= 0 && this.editorView.state.doc.nodeAt(pos.inside)
     let disableDropCursor = node && node.type.spec.disableDropCursor
-    let disabled = typeof disableDropCursor == "function" ? disableDropCursor(this.editorView, pos) : disableDropCursor
+    let disabled = typeof disableDropCursor == "function" ? disableDropCursor(this.editorView, pos, event) : disableDropCursor
 
     if (pos && !disabled) {
       let target: number | null = pos.pos


### PR DESCRIPTION
It's useful to be able to disable the drop cursor conditionally, depending on what kind of thing is being dragged. In my case I wanted to only show the block level (horizontal) drop cursor when an image file is dragged over the editor.

Passing the DragEvent makes this more symmetrical with EditorView.handleDrop.

It may be this wasn't provided in the past because browsers only provided kind/type information on drop, not during the drag, but it seems like that has changed: https://caniuse.com/mdn-api_datatransfer_items

Here's how I'm using it (on all my nodes that have text content):

```
disableDropCursor(editor: EditorView, pos: number, event: DragEvent) {
  const items = [...event.dataTransfer?.items ?? []]
  return items.length == 0 || !items[0].type.match(/^text\//)
}
```