### PR TITLE
Differentiate block vs. inline insert via CSS

### DIFF
--- a/src/dropcursor.ts
+++ b/src/dropcursor.ts
@@ -105,10 +105,20 @@ class DropCursorView {
       parentLeft = rect.left - parent.scrollLeft
       parentTop = rect.top - parent.scrollTop
     }
+    
+    const width = rect.right - rect.left
+    const height = rect.bottom - rect.top
+
+    if(this.class) {
+      this.element.classList.add(
+        width > height ? "block" : "inline"
+      )
+    }
+
     this.element.style.left = (rect.left - parentLeft) + "px"
     this.element.style.top = (rect.top - parentTop) + "px"
-    this.element.style.width = (rect.right - rect.left) + "px"
-    this.element.style.height = (rect.bottom - rect.top) + "px"
+    this.element.style.width = width + "px"
+    this.element.style.height = height + "px"
   }
 
   scheduleRemoval(timeout: number) {


### PR DESCRIPTION
Hi, I wondered if you'd consider supporting some additional CSS styling. 

Visually the drop cursor seems to have two modes: a horizontal (block) insert; and a vertical (inline) caret-like insert - I'd like to be able to differentiate and style them separately but currently the API allows only for a single CSS class. I'm proposing that if the `class` configuration is being utilised then some additional classes are appended allowing for higher specificity. Alternatively a `data-*` attribute would work.