### PR TITLE
Add New Feature

### DIFF
--- a/src/dropcursor.ts
+++ b/src/dropcursor.ts
@@ -27,6 +27,13 @@ export function dropCursor(options: DropCursorOptions = {}): Plugin {
   })
 }
 
+// Add disableDropCursor to NodeSpec
+declare module "prosemirror-model" {
+  interface NodeSpec {
+    disableDropCursor?: boolean | ((view: EditorView, pos: { pos: number, inside: number } | null, event: DragEvent) => boolean)
+  }
+}
+
 class DropCursorView {
   width: number
   color: string | undefined

--- a/src/dropcursor.ts
+++ b/src/dropcursor.ts
@@ -79,21 +79,29 @@ class DropCursorView {
     }
   }
 
+  private setVisiableByInactiveClass(visible: boolean) {
+    if (!this.element || !this.inactiveClass) {
+      return
+    }
+    if (visible) {
+      this.element.classList.remove(this.inactiveClass)
+    } else {
+      this.element.classList.add(this.inactiveClass)
+    }
+  }
+
   private setVisible(visible: boolean) {
-    if (this.element) {
-      if (visible) {
-        if (this.inactiveClass) {
-          this.element.classList.remove(this.inactiveClass)
-        } else {
-          this.element.style.display = ''
-        }
-      } else {
-        if (this.inactiveClass) {
-          this.element.classList.add(this.inactiveClass)
-        } else {
-          this.element.style.display = 'none'
-        }
-      }
+    if (this.inactiveClass) {
+      this.setVisiableByInactiveClass(visible)
+      return
+    }
+    if (!this.element) {
+      return
+    }
+    if (visible) {
+        this.element.style.display = ''
+    } else {
+        this.element.style.display = 'none'
     }
   }
 


### PR DESCRIPTION
1. Added some options to keep the `cursor element` from being removed during drag operations, ensuring the continuity of animations like `transition`.
2. Added the `disableDropCursor` type to `prosemirror-model` to provide code hints when writing `NodeSpec`.
3. Add cursor `dropEffect` when `disableDropCursor` option triggered.